### PR TITLE
Update Carbon Dependency to Support Version 3.2.4 in jerome/filterable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "illuminate/database": "^10.0|^11.0",
         "illuminate/http": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",
-        "nesbot/carbon": "^2.72",
+        "nesbot/carbon": "^2.72|^3.0",
         "spatie/laravel-package-tools": "^1.11"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d59ad5e09d99c1716afc24e793bcdf4e",
+    "content-hash": "3e47374a7ab25b0d5a65876f051dd9b1",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
**Summary:**

This PR resolve #2 through updates the `composer.json` of the `jerome/filterable` package to allow compatibility with `nesbot/carbon` version `3.2.4`. This change aims to resolve the version conflict issue when attempting to install `jerome/filterable` alongside the newer version of Carbon.

**Background:**

A dependency conflict occurs with `nesbot/carbon` when installing `jerome/filterable`, as the required version of Carbon is `^2.72` but many projects are now using Carbon `3.2.4`. This update makes `jerome/filterable` compatible with the newer version of Carbon.

**Changes:**

- Modified `composer.json`:
  - Updated the `require` section to allow `nesbot/carbon` versions `^2.72` or `^3.2.4`.

**Benefits:**

- Resolves dependency conflicts with `nesbot/carbon`.
- Broader compatibility with projects using newer versions of Carbon.
- Eases installation process for users with updated dependencies.

**Testing:**

- Ensure that the package installs correctly when `nesbot/carbon` version `3.2.4` is present.
- Run existing unit tests to verify that the update does not break any existing functionality.

**Discussion Points:**

- Consideration for any potential breaking changes for users on older versions of Carbon.
- Review of any other dependencies that might be affected by this change.

**Additional Notes:**

- This PR does not include changes to the library's code but updates the dependency management.
- Further testing may be required to ensure compatibility with other versions of dependencies.