### PR TITLE
Fix for Argument Acceptance in `make:filter` Command

### DIFF
--- a/src/Filterable/Console/MakeFilterCommand.php
+++ b/src/Filterable/Console/MakeFilterCommand.php
@@ -3,10 +3,11 @@
 namespace Filterable\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'make:filter')]
-class MakeFilterCommand extends Command
+class MakeFilterCommand extends GeneratorCommand
 {
     /**
      * The console command name.

--- a/tests/MakeFilterCommandTest.php
+++ b/tests/MakeFilterCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Filterable\Tests;
+
+/**
+ * Class MakeFilterCommandTest.
+ *
+ * @covers \Filterable\Console\MakeFilterCommand
+ */
+final class MakeFilterCommandTest extends TestCase
+{
+    public function testItCanGenerateANewFilterClass(): void
+    {
+        $this->artisan('make:filter', ['name' => 'FooFilter'])
+            ->assertExitCode(0);
+
+        $this->assertFileExists(app_path('Filters/FooFilter.php'));
+    }
+}


### PR DESCRIPTION
This Pull Request resolves issue #6 where the `make:filter` Artisan command did not accept any arguments. The changes allow the command to accept a filter class name as an argument, enabling the creation of a filter class with the specified name.

**Background & Issue:**

The `make:filter` command was not working as expected because it did not accept a class name argument. Users trying to create a new filter class with the command would receive an error: "No arguments expected for 'make:filter' command, got '{ClassName}'." This issue was tracked as issue #6.

**Changes Made:**

- Updated the Artisan command definition to correctly parse the expected argument.
- Ensured the command handler is now correctly generating the filter class based on the provided argument.

**Validation:**

- Manually tested the `make:filter` command after changes.
- Ensured existing functionality remained unaffected.

**Links:**

- Issue URL: [Link to the issue #6]
- Compare URL: https://github.com/Thavarshan/filterable/compare/main...fix/issue-6

**Usage:**

After merging this PR, users can run the following command to create a new filter class:
```bash
php artisan make:filter {FilterClassName}
```
Replace `{FilterClassName}` with the desired class name for the filter.

**Merging this PR:**

This PR is open for review by maintainers and can be merged into the `main` branch upon approval.