### PR TITLE
Update filter.stub to use typed property declaration

### DIFF
--- a/src/Filterable/Console/stubs/filter.stub
+++ b/src/Filterable/Console/stubs/filter.stub
@@ -8,11 +8,11 @@ use Illuminate\Database\Eloquent\Builder;
 class {{ class }} extends Filter
 {
     /**
-     * Attributes to filters from.
+     * Registered filters to operate upon.
      *
-     * @var array
+     * @var array<string>
      */
-    protected $filters = ['filter'];
+    protected array $filters = ['filter'];
 
     /**
      * Filter the query by a given attribute value.


### PR DESCRIPTION
This Pull Request resolves issue #8 by updating the `filter.stub` file to include a type declaration for the `$filters` property, ensuring compatibility with PHP 7.4 and above where property types are supported. The explicit array type declaration enforces that `$filters` is always an array, preventing type errors.

**Background & Issue:**

In environments running PHP 7.4+, the `filter.stub` was causing a fatal error due to the lack of a type declaration for the `$filters` property. This update ensures that when a filter class is generated, it will have a properly typed property, as required by PHP 7.4+.

**Changes Made:**

- Added a type declaration to the `$filters` property within the `filter.stub` file.

**Before:**

```php
protected $filters = ['filter'];
```

**After:**

```php
protected array $filters = ['filter'];
```

**Testing:**

- Generated a new filter class using the updated stub to ensure the `$filters` property is correctly typed.
- Ensured that the new filter class works as expected without any type errors.

**PHP Version Compatibility:**

- This change is compatible with PHP 7.4 and above. Projects using an earlier version of PHP should update accordingly to accommodate typed properties.

**Additional Notes:**

- This change adheres to modern PHP standards and improves code reliability by leveraging PHP's type system.