### PR TITLE
Fix caching feature flag being ignored

### DIFF
--- a/src/Filterable/Filter.php
+++ b/src/Filterable/Filter.php
@@ -104,7 +104,6 @@ abstract class Filter implements FilterContract
         // Set up the dependencies
         if ($cache) {
             $this->setCacheHandler($cache);
-            $this->enableFeature('caching');
         }
 
         if ($logger) {

--- a/tests/Unit/CachingTest.php
+++ b/tests/Unit/CachingTest.php
@@ -68,6 +68,20 @@ class CachingTest extends TestCase
         $this->assertCount(1, $results);
     }
 
+    public function test_cache_dependency_does_not_enable_caching_when_disabled_by_configuration(): void
+    {
+        $this->cache->shouldNotReceive('remember');
+
+        $filter = new TestFilter($this->request, $this->cache);
+
+        $this->assertFalse($filter->hasFeature('caching'));
+
+        $filter->apply($this->builder);
+        $results = $filter->get();
+
+        $this->assertInstanceOf(Collection::class, $results);
+    }
+
     public function test_builds_appropriate_cache_key(): void
     {
         $requestWithParams = Request::create('/?name=John&status=active', 'GET');

--- a/tests/Unit/FilterTest.php
+++ b/tests/Unit/FilterTest.php
@@ -204,15 +204,17 @@ class FilterTest extends TestCase
         $filter->apply($this->builder);
     }
 
-    public function test_enables_features_by_constructor_dependencies(): void
+    public function test_constructor_cache_dependency_respects_feature_defaults(): void
     {
         $this->cache->shouldReceive('remember')->andReturn(collect());
 
         // Create filter with cache and logger
         $filter = new TestFilter($this->request, $this->cache, $this->logger);
 
-        // Verify features were enabled
-        $this->assertTrue($filter->hasFeature('caching'));
+        // Cache should remain disabled unless explicitly enabled in configuration or code
+        $this->assertFalse($filter->hasFeature('caching'));
+
+        // Logger injection still enables logging for compatibility with existing behavior
         $this->assertTrue($filter->hasFeature('logging'));
     }
 
@@ -241,6 +243,7 @@ class FilterTest extends TestCase
 
         // Create filter with cache
         $filter = new TestFilter($this->request, $this->cache);
+        $filter->enableFeature('caching');
 
         // Verify caching is enabled
         $this->assertTrue($filter->hasFeature('caching'));


### PR DESCRIPTION
## Purpose

Fix issue #37: disabling the `caching` feature in configuration did not actually prevent the filter from using cached query results when a cache repository was injected. As a result, repeated requests could return stale or unfiltered data instead of re-running the filter logic.

## Approach

Remove the constructor behavior that implicitly enabled caching whenever a cache repository was provided. Caching now respects the configured feature defaults, so `caching: false` stays off unless it is explicitly enabled by code or configuration. Add regression coverage for both the disabled-by-default path and the explicit-enable path.

#### Open Questions and Pre-Merge TODOs

-   [x] Confirmed with focused PHPUnit coverage that the disabled path no longer calls the cache repository.
    This was verified by running `./vendor/bin/phpunit tests/Unit/CachingTest.php tests/Unit/FilterTest.php`.

## Learning

The cache repository injection should not be treated as an implicit feature toggle. The constructor must preserve configuration-driven feature defaults, while callers who want caching can still enable it explicitly.
